### PR TITLE
V3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   },
   "author": "balena.io",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "bugs": {
     "url": "https://github.com/balena-io-modules/balena-release/issues"
   },

--- a/package.json
+++ b/package.json
@@ -32,11 +32,9 @@
   "homepage": "https://github.com/balena-io-modules/balena-release#readme",
   "dependencies": {
     "@types/bluebird": "^3.5.18",
-    "@types/lodash": "^4.14.87",
     "@types/node": "^8.0.55",
     "@types/request": "^2.0.8",
     "bluebird": "^3.5.1",
-    "lodash": "^4.17.4",
     "pinejs-client-request": "^7.1.0",
     "resin-compose-parse": "^2.0.0",
     "typed-error": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "balena-lint --typescript src test",
     "lint-fix": "balena-lint --typescript --fix src test",
     "test:node": "mocha -r ts-node/register --reporter spec test/**/*.spec.ts",
-    "test:ts-compatibility": "npx typescript@~3.4.0 --noEmit --project ./tsconfig.dist.json",
+    "test:ts-compatibility": "npx typescript@~3.9.0 --noEmit --project ./tsconfig.dist.json",
     "test": "npm run build && npm run test:ts-compatibility && npm run test:node",
     "prepack": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/request": "^2.0.8",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4",
-    "pinejs-client": "^4.2.3",
+    "pinejs-client-request": "^7.1.0",
     "resin-compose-parse": "^2.0.0",
     "typed-error": "^3.0.0"
   },

--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,4 @@
+type: 'node'
+upstream:
+  - repo: 'pinejs-client-request'
+    url: 'https://github.com/balena-io-modules/pinejs-client-request'

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 
-import ApiClient = require('pinejs-client');
+import { PinejsClientRequest } from 'pinejs-client-request';
 import { Composition } from 'resin-compose-parse';
 
 import * as models from './models';
@@ -24,8 +24,8 @@ export interface ClientConfig {
 	auth: string;
 }
 
-export function createClient(config: ClientConfig): ApiClient {
-	return new ApiClient({
+export function createClient(config: ClientConfig): PinejsClientRequest {
+	return new PinejsClientRequest({
 		apiPrefix: `${config.apiEndpoint}/v6/`,
 		passthrough: {
 			headers: {
@@ -42,7 +42,7 @@ export interface Request {
 	 * configure `apiPrefix` appropriately.
 	 *
 	 * ```
-	 * import Pine = require('pinejs-client');
+	 * import Pine = require('pinejs-client-request');
 	 * const client = new Pine({
 	 *   apiPrefix: 'https://api.balena-cloud.com/v5',
 	 *   passthrough: {
@@ -56,7 +56,7 @@ export interface Request {
 	 * You can use the `createClient` convenience function of this module to create
 	 * a client that can reused across requests.
 	 */
-	client: ApiClient;
+	client: PinejsClientRequest;
 
 	/**
 	 * The ID of the user the release should belong to. The user authenticated via `client`
@@ -154,7 +154,7 @@ export async function create(req: Request): Promise<Response> {
 }
 
 export async function updateRelease(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	id: number,
 	body: Partial<models.ReleaseAttributes>,
 ): Promise<models.ReleaseModel> {
@@ -162,7 +162,7 @@ export async function updateRelease(
 }
 
 export async function updateImage(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	id: number,
 	body: Partial<models.ImageAttributes>,
 ): Promise<models.ImageModel> {
@@ -171,19 +171,22 @@ export async function updateImage(
 
 // Helpers
 
-async function getUser(api: ApiClient, id: number): Promise<models.UserModel> {
+async function getUser(
+	api: PinejsClientRequest,
+	id: number,
+): Promise<models.UserModel> {
 	return models.get(api, 'user', id);
 }
 
 async function getApplication(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	id: number,
 ): Promise<models.ApplicationModel> {
 	return models.get(api, 'application', id);
 }
 
 async function getOrCreateService(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	body: models.ServiceAttributes,
 ): Promise<models.ServiceModel> {
 	return models.getOrCreate(api, 'service', body, {
@@ -193,14 +196,14 @@ async function getOrCreateService(
 }
 
 async function createRelease(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	body: models.ReleaseAttributes,
 ): Promise<models.ReleaseModel> {
 	return models.create(api, 'release', body);
 }
 
 async function createImage(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	release: number,
 	labels: Dict<string> | undefined,
 	envvars: Dict<string> | undefined,

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import * as Promise from 'bluebird';
+import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 
 import ApiClient = require('pinejs-client');
@@ -97,62 +97,63 @@ export interface Response {
 /**
  * This is the entry point for deploying a docker-compose.yml to devices.
  */
-export function create(req: Request): Promise<Response> {
+export async function create(req: Request): Promise<Response> {
 	const api = req.client;
 
 	// Ensure that the user and app exist and the user has access to them.
-	return Promise.join(
+	const [user, application] = await Promise.all([
 		getUser(api, req.user),
 		getApplication(api, req.application),
-		(user, application) => {
-			return createRelease(api, {
-				is_created_by__user: user.id,
-				belongs_to__application: application.id,
-				composition: req.composition,
-				commit: req.commit,
-				status: 'running',
-				source: req.source,
-				start_timestamp: new Date(),
-			})
-				.then((release) => {
-					return { release, serviceImages: {} } as Response;
-				})
-				.tap((res) => {
-					// Create services and associated image, labels and env vars
-					return Promise.map(
-						_.toPairs(req.composition.services),
-						([serviceName, serviceDescription]) => {
-							return getOrCreateService(api, {
-								application: application.id,
-								service_name: serviceName,
-							}).tap((service) => {
-								// Create images and attach labels and env vars
-								return createImage(
-									api,
-									res.release.id,
-									serviceDescription.labels,
-									serviceDescription.environment,
-									{
-										is_a_build_of__service: service.id,
-										status: 'running',
-										start_timestamp: new Date(),
-									},
-								).tap((img) => {
-									// Amend response with image details for the service
-									res.serviceImages[serviceName] = img;
-								});
-							});
-						},
-						{
-							concurrency: MAX_CONCURRENT_REQUESTS,
-						},
-					);
-				});
+	]);
+
+	const release = await createRelease(api, {
+		is_created_by__user: user.id,
+		belongs_to__application: application.id,
+		composition: req.composition,
+		commit: req.commit,
+		status: 'running',
+		source: req.source,
+		start_timestamp: new Date(),
+	});
+
+	const res = { release, serviceImages: {} } as Response;
+
+	// Create services and associated image, labels and env vars
+	await Bluebird.map(
+		_.toPairs(req.composition.services),
+		async ([serviceName, serviceDescription]) => {
+			const service = await getOrCreateService(api, {
+				application: application.id,
+				service_name: serviceName,
+			});
+
+			// Create images and attach labels and env vars
+			const img = await createImage(
+				api,
+				res.release.id,
+				serviceDescription.labels,
+				serviceDescription.environment,
+				{
+					is_a_build_of__service: service.id,
+					status: 'running',
+					start_timestamp: new Date(),
+				},
+			);
+
+			// Amend response with image details for the service
+			res.serviceImages[serviceName] = img;
+
+			return service;
+		},
+		{
+			concurrency: MAX_CONCURRENT_REQUESTS,
 		},
 	);
+
+	return res;
 }
 
-export function updateRelease(
+export async function updateRelease(
 	api: ApiClient,
 	id: number,
 	body: Partial<models.ReleaseAttributes>,
@@ -160,7 +161,7 @@ export function updateRelease(
 	return models.update(api, 'release', id, body);
 }
 
-export function updateImage(
+export async function updateImage(
 	api: ApiClient,
 	id: number,
 	body: Partial<models.ImageAttributes>,
@@ -170,18 +171,18 @@ export function updateImage(
 
 // Helpers
 
-function getUser(api: ApiClient, id: number): Promise<models.UserModel> {
+async function getUser(api: ApiClient, id: number): Promise<models.UserModel> {
 	return models.get(api, 'user', id);
 }
 
-function getApplication(
+async function getApplication(
 	api: ApiClient,
 	id: number,
 ): Promise<models.ApplicationModel> {
 	return models.get(api, 'application', id);
 }
 
-function getOrCreateService(
+async function getOrCreateService(
 	api: ApiClient,
 	body: models.ServiceAttributes,
 ): Promise<models.ServiceModel> {
@@ -191,61 +192,61 @@ function getOrCreateService(
 	});
 }
 
-function createRelease(
+async function createRelease(
 	api: ApiClient,
 	body: models.ReleaseAttributes,
 ): Promise<models.ReleaseModel> {
 	return models.create(api, 'release', body);
 }
 
-function createImage(
+async function createImage(
 	api: ApiClient,
 	release: number,
 	labels: Dict<string> | undefined,
 	envvars: Dict<string> | undefined,
 	body: models.ImageAttributes,
 ): Promise<models.ImageModel> {
-	return models
-		.create<models.ImageModel, models.ImageAttributes>(api, 'image', body)
-		.tap((image) => {
-			return models
-				.create<models.ReleaseImageModel, models.ReleaseImageAttributes>(
-					api,
-					'image__is_part_of__release',
-					{
-						is_part_of__release: release,
-						image: image.id,
-					},
-				)
-				.tap((releaseImage) => {
-					return Promise.map(
-						_.toPairs(labels),
-						([name, value]) => {
-							return models.create(api, 'image_label', {
-								release_image: releaseImage.id,
-								label_name: name,
-								value: (value || '').toString(),
-							});
-						},
-						{
-							concurrency: MAX_CONCURRENT_REQUESTS,
-						},
-					);
-				})
-				.tap((releaseImage) => {
-					return Promise.map(
-						_.toPairs(envvars),
-						([name, value]) => {
-							return models.create(api, 'image_environment_variable', {
-								release_image: releaseImage.id,
-								name,
-								value: (value || '').toString(),
-							});
-						},
-						{
-							concurrency: MAX_CONCURRENT_REQUESTS,
-						},
-					);
-				});
-		});
+	const image = await models.create<models.ImageModel, models.ImageAttributes>(
+		api,
+		'image',
+		body,
+	);
+
+	const releaseImage = await models.create<
+		models.ReleaseImageModel,
+		models.ReleaseImageAttributes
+	>(api, 'image__is_part_of__release', {
+		is_part_of__release: release,
+		image: image.id,
+	});
+
+	await Bluebird.map(
+		_.toPairs(labels),
+		([name, value]) => {
+			return models.create(api, 'image_label', {
+				release_image: releaseImage.id,
+				label_name: name,
+				value: (value || '').toString(),
+			});
+		},
+		{
+			concurrency: MAX_CONCURRENT_REQUESTS,
+		},
+	);
+
+	await Bluebird.map(
+		_.toPairs(envvars),
+		([name, value]) => {
+			return models.create(api, 'image_environment_variable', {
+				release_image: releaseImage.id,
+				name,
+				value: (value || '').toString(),
+			});
+		},
+		{
+			concurrency: MAX_CONCURRENT_REQUESTS,
+		},
+	);
+
+	return image;
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -26,7 +26,7 @@ export interface ClientConfig {
 
 export function createClient(config: ClientConfig): ApiClient {
 	return new ApiClient({
-		apiPrefix: `${config.apiEndpoint}/v5/`,
+		apiPrefix: `${config.apiEndpoint}/v6/`,
 		passthrough: {
 			headers: {
 				Authorization: config.auth,

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,5 +1,3 @@
-import * as Promise from 'bluebird';
-
 import ApiClient = require('pinejs-client');
 import { Expand, Filter, ODataOptions } from 'pinejs-client/core';
 import { Composition } from 'resin-compose-parse';

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,6 @@
-import ApiClient = require('pinejs-client');
-import { Expand, Filter, ODataOptions } from 'pinejs-client/core';
-import { Composition } from 'resin-compose-parse';
+import type { PinejsClientRequest } from 'pinejs-client-request';
+import type { Expand, Filter, ODataOptions } from 'pinejs-client-core';
+import type { Composition } from 'resin-compose-parse';
 
 import * as errors from './errors';
 
@@ -90,29 +90,26 @@ export interface ReleaseImageModel extends ReleaseImageAttributesBase {
 // Helpers
 
 export function getOrCreate<T, U, V extends Filter>(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	resource: string,
 	body: U,
 	filter: V,
 ): Promise<T> {
-	return create(api, resource, body).catch(
-		// TODO: Drop this in the next major release (using the /v6 endpoint)
-		// and only check for UniqueConstraintError
-		errors.ObjectDoesNotExistError,
-		errors.UniqueConstraintError,
-		() => {
+	return create(api, resource, body).catch((error) => {
+		if (error instanceof errors.UniqueConstraintError) {
 			return find<T>(api, resource, { $filter: filter }).then((obj) => {
 				if (obj.length > 0) {
 					return obj[0];
 				}
 				throw new errors.ObjectDoesNotExistError();
 			});
-		},
-	) as Promise<T>;
+		}
+		throw error;
+	}) as Promise<T>;
 }
 
 export function create<T, U>(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	resource: string,
 	body: U,
 ): Promise<T> {
@@ -120,7 +117,7 @@ export function create<T, U>(
 }
 
 export function update<T, U>(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	resource: string,
 	id: number,
 	body: U,
@@ -131,7 +128,7 @@ export function update<T, U>(
 }
 
 export function find<T>(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	resource: string,
 	options: ODataOptions,
 ): Promise<T[]> {
@@ -141,7 +138,7 @@ export function find<T>(
 }
 
 export function get<T>(
-	api: ApiClient,
+	api: PinejsClientRequest,
 	resource: string,
 	id: number,
 	expand?: Expand,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2018",
     "outDir": "./build",
     "noUnusedParameters": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
* Drop lodash in favor of native methods
* Move from pinejs-client v4 to pinejs-client-request v7
* **BREAKING** Return native promises from all methods
* **BREAKING** Bump the TS compatibility target to 3.9
* Update to the v6 balena-api model
* **BREAKING** Build for es2018 environments
* **BREAKING** Stop actively supporting node<10

Change-type: major