### PR TITLE
Allow draft release creation and versioning

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -84,6 +84,16 @@ export interface Request {
 	 * The external identifier for the release.
 	 */
 	commit: string;
+
+	/**
+	 * Mark the created release as final/draft
+	 */
+	is_final?: boolean;
+
+	/**
+	 * Release version string
+	 */
+	semver?: string;
 }
 
 export interface Response {
@@ -111,6 +121,10 @@ export async function create(req: Request): Promise<Response> {
 		status: 'running',
 		source: req.source,
 		start_timestamp: new Date(),
+		is_final: !!req.is_final,
+
+		// Only set semver if provided on the request
+		...(!!req.semver && { semver: req.semver }),
 	});
 
 	const res = { release, serviceImages: {} } as Response;

--- a/src/models.ts
+++ b/src/models.ts
@@ -17,6 +17,7 @@ interface ReleaseAttributesBase {
 	source: string;
 	start_timestamp: Date;
 	end_timestamp?: Date;
+	contract?: string;
 }
 
 // tslint:disable-next-line no-empty-interface
@@ -46,6 +47,8 @@ export interface ServiceAttributes extends ServiceAttributesBase {
 export interface ReleaseAttributes extends ReleaseAttributesBase {
 	is_created_by__user: number;
 	belongs_to__application: number;
+	semver?: string;
+	is_final?: boolean;
 }
 
 export interface ImageAttributes extends ImageAttributesBase {
@@ -73,6 +76,8 @@ export interface ServiceModel extends ServiceAttributesBase {
 
 export interface ReleaseModel extends ReleaseAttributesBase {
 	id: number;
+	semver: string;
+	is_final: boolean;
 }
 
 export interface ImageModel extends ImageAttributesBase {


### PR DESCRIPTION
Allows to set `is_final` release attribute on release creation. It also adds `semver`
and `contract` to the release attribute model.

Change-type: minor